### PR TITLE
Adjust testsuite for perl-versions

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: perl -V
       - name: Makefile.PL
         run: perl -I$(pwd) Makefile.PL
@@ -35,9 +35,23 @@ jobs:
 ## Test multiple versions of Perl using perl-tester
 ##
 
+  perl-versions:
+    runs-on: ubuntu-latest
+    name: List Perl versions
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - id: action
+        uses: perl-actions/perl-versions@v1
+        with:
+          since-perl: v5.8
+          with-devel: true
+
   linux:
     name: "linux ${{ matrix.perl-version }}"
-    needs: [ubuntu]
+    needs:
+      - ubuntu
+      - perl-versions
     env:
       PERL_USE_UNSAFE_INC: 0
       AUTHOR_TESTING: 1
@@ -49,125 +63,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        perl-version:
-          [
-            "perl-tester:5.38",
-            "perl-tester:5.36",
-            "perl-tester:5.34",
-            "perl-tester:5.32",
-            "perl-tester:5.30",
-            "perl-tester:5.28",
-            "perl-tester:5.26",
-            "perl-tester:5.24",
-            "perl-tester:5.22",
-            "perl-tester:5.20",
-            "perl-tester:5.18",
-            "perl-tester:5.16",
-            "perl-tester:5.14",
-            "perl-tester:5.12",
-            "perl-tester:5.10",
-            "perl-tester:5.8",
-            "perl:5.6",
-          ]
+        perl-version: ${{ fromJson (needs.perl-versions.outputs.perl-versions) }}
 
-    container:
-      image: perldocker/${{ matrix.perl-version }}
+    container: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: perl -V
       - name: Makefile.PL
         run: perl -I$(pwd) Makefile.PL
       - run: make test
 
-##
-## Testing on macOS
-##
-
-  macOS:
-    needs: [ubuntu, linux]
+  perl-56:
+    name: "Perl 5.6"
+    needs: [ubuntu]
     env:
       PERL_USE_UNSAFE_INC: 0
       AUTHOR_TESTING: 1
       AUTOMATED_TESTING: 1
       RELEASE_TESTING: 1
 
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        perl-version: [latest]
+    container:
+      image: perldocker/perl:5.6
 
     steps:
+      # cannot use v4 with that container
       - uses: actions/checkout@v3
       - run: perl -V
       - name: Makefile.PL
         run: perl -I$(pwd) Makefile.PL
       - run: make test
-
-##
-## Testing on windows
-##
-
-  windows:
-    needs: [ubuntu, linux]
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Perl
-        run: |
-          choco install strawberryperl
-          echo 'C:\strawberry\c\bin'         >> $GITHUB_PATH
-          echo 'C:\strawberry\perl\site\bin' >> $GITHUB_PATH
-          echo 'C:\strawberry\perl\bin'      >> $GITHUB_PATH
-      - run: perl -V
-      - run: perl Makefile.PL
-      - run: make
-      - name: Run Tests
-        run: make test
-        env:
-          AUTHOR_TESTING: 1
-          RELEASE_TESTING: 1
-
-##
-## Testing on windows: using multiple Perl versions
-##
-
-  # windows:
-  #   name: windows Perl v${{ matrix.perl-version }}
-  #   needs: [ubuntu, linux]
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ["windows-latest"]
-  #       perl-version:
-  #         - "5.34"
-  #         - "5.32"
-  #         - "5.30"
-  #         - "5.28"
-  #         - "5.26"
-  #         - "5.24"
-  #         # - "5.22"
-  #         # - "5.20.3"
-  #         # - "5.18.4"
-  #         # - "5.16.3"
-  #         # - "5.14.4"
-  #         # - "5.12.5"
-  #         # - "5.10.1"
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set Up Perl
-  #       uses: shogo82148/actions-setup-perl@v1.16.0
-  #       with:
-  #         perl-version: ${{ matrix.perl-version }}
-  #     - run: perl -V
-  #     - run: perl Makefile.PL
-  #     - run: make
-  #     - name: Run Tests
-  #       run: make test
-  #       env:
-  #         AUTHOR_TESTING: 1
-  #         RELEASE_TESTING: 1


### PR DESCRIPTION
Remove macOS and windows pipeline as they are
discouraged by GitHub as they consume more ressource and brings a low value.

Use the `perl-actions/perl-versions@v1` pipeline to use a dynamic list of current Perl versions.